### PR TITLE
Fix RPCException mapping between "event_base" and "event_instance" 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,3 +31,6 @@ local_db_server_stop:
     fi
 
 clean: imports fmt lint
+
+run:
+	go run cmd/example.go -c `pwd`/config/config.json

--- a/event_store.go
+++ b/event_store.go
@@ -370,7 +370,8 @@ func (es *eventStore) SaveToDB(evtsToAdd []UnaddedEvent) {
 		}
 		processedDetail := event.ExtraArgs
 
-		// We add service_id to hash as
+		// We add service_id to hash generic data as to map between
+		// tables: "event_base" and "event_instance" for RPC Exception
 		genericDataHash := util.Hash(genericData, serviceId)
 		processedDataHash := util.Hash(processedData)
 		processedDetailHash := util.Hash(processedDetail)

--- a/event_store.go
+++ b/event_store.go
@@ -334,6 +334,28 @@ func (es *eventStore) SaveToDB(evtsToAdd []UnaddedEvent) {
 			continue
 		}
 
+		// Get service name from config.json, but for RPCException
+		// we consider service_aggregation_mapping to override service
+		// with rpc exception to `*_rpc` suffix, e.g. merchant_be -> merchant_be_rpc
+		service, ok := es.GetServiceAggregationMapping(rawEvent)
+		if ok {
+			rawEvent.Service = service
+		} else {
+			continue
+		}
+
+		// Get service id from config.json, e.g. "merchant_be": {"service_id": 4}
+		serviceId, ok := es.ds.GetServicesMap()[rawEvent.Service]
+		if !ok {
+			continue
+		}
+
+		// Get environment id from config.json, e.g. "prod": {"environment_id": 1}
+		environmentId, ok := es.ds.GetEnvironmentsMap()[rawEvent.Environment]
+		if !ok {
+			continue
+		}
+
 		genericData := event.Data
 		event, err = globalRule.ProcessFilter(event, "base")
 		if err != nil {
@@ -348,26 +370,11 @@ func (es *eventStore) SaveToDB(evtsToAdd []UnaddedEvent) {
 		}
 		processedDetail := event.ExtraArgs
 
-		genericDataHash := util.Hash(genericData)
+		// We add service_id to hash as
+		genericDataHash := util.Hash(genericData, serviceId)
 		processedDataHash := util.Hash(processedData)
 		processedDetailHash := util.Hash(processedDetail)
 
-		service, ok := es.GetServiceAggregationMapping(rawEvent)
-		if ok {
-			// Override service with rpc exception to `*_rpc` suffix
-			rawEvent.Service = service
-		} else {
-			continue
-		}
-
-		serviceId, ok := es.ds.GetServicesMap()[rawEvent.Service]
-		if !ok {
-			continue
-		}
-		environmentId, ok := es.ds.GetEnvironmentsMap()[rawEvent.Environment]
-		if !ok {
-			continue
-		}
 		//create base event
 		eventBase = EventBase{
 			ServiceId:          serviceId.Id,

--- a/util/util.go
+++ b/util/util.go
@@ -64,11 +64,23 @@ func Avg(vals ...int) int {
 	return avg
 }
 
-func Hash(i interface{}) string {
+func Hash(i interface{}, args ...interface{}) string {
+	var b []byte
 	b, err := json.Marshal(i)
 	if err != nil {
 		fmt.Println("Error", err)
 	}
+
+	if args != nil {
+		for _, arg := range args {
+			if b_arr, err := json.Marshal(arg); err != nil {
+				fmt.Println("Error parsing additional args", err)
+			} else {
+				b = append(b, b_arr...)
+			}
+		}
+	}
+
 	hasher := sha256.New()
 	hasher.Write(b)
 	return base64.URLEncoding.EncodeToString(hasher.Sum(nil))


### PR DESCRIPTION
Fix the issue that current record with RPCException mapped to old service id in event_instance table

After fix, the local test table are:

Event_base:
![Screen Shot 2019-10-29 at 2 38 08 PM](https://user-images.githubusercontent.com/52468479/67811350-cbd0c180-fa59-11e9-9a56-1b32777a283b.png)

Event_instance:

![Screen Shot 2019-10-29 at 2 37 56 PM](https://user-images.githubusercontent.com/52468479/67811383-dbe8a100-fa59-11e9-946a-ae6636e9862e.png)
